### PR TITLE
Hide any jobs that's name ends in '-pullrequests'

### DIFF
--- a/jenkins/files/config.xml
+++ b/jenkins/files/config.xml
@@ -35,7 +35,7 @@
       </jobNames>
       <jobFilters/>
       <columns/>
-      <includeRegex>.*</includeRegex>
+      <includeRegex>^(?!.*-pullrequests$).*$</includeRegex>
       <recurse>false</recurse>
       <title>Build Radiator</title>
       <config>


### PR DESCRIPTION
These jobs often fail so we should promote them on the build radiator
