### PR TITLE
Explicitly set jenkins_job_builder install method to pip

### DIFF
--- a/jenkins/vars/jenkins.yml
+++ b/jenkins/vars/jenkins.yml
@@ -16,6 +16,7 @@ jenkins_job_builder_user_name: '{{ jenkins_user }}'
 jenkins_job_builder_user_group: '{{ jenkins_user }}'
 jenkins_job_builder_file_jobs_group: '{{ jenkins_user }}'
 jenkins_job_builder_file_jobs_owner: '{{ jenkins_user }}'
+jenkins_job_builder_install_method: 'pip'
 
 postgresql_databases:
   - name: lighthouse


### PR DESCRIPTION
For some reason jenkins_job_builder isn't accepting it's default value. Explicitly setting it fixes the issue.
