### PR TITLE
Pull in dstl-lighthouse-builder submodules

### DIFF
--- a/jenkins/templates/jobs/lighthouse.yml.j2
+++ b/jenkins/templates/jobs/lighthouse.yml.j2
@@ -50,6 +50,8 @@
             url: git@github.com:livestax/dstl-infrastructure.git
             branches:
                 - origin/master
+            submodule:
+                recursive: true
     triggers:
         - github
         - reverse:


### PR DESCRIPTION
This is needed so that the any submodules the infra repo has will be pulled
down.
