### PR TITLE
Speed up rysncing during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ method:
     > rsync --recursive \
             -e 'ssh -i secrets/preview.deploy.pem' \
             . \
-            centos@ci.lighthouse.pw:/tmp/bootstrap
+            centos@ci.lighthouse.pw:/tmp/bootstrap \
+            --exclude-from "rsync_exclude.txt"
 
 With our folder rsynced across we can now ssh in and run the bootstrap:
 

--- a/rsync_exclude.txt
+++ b/rsync_exclude.txt
@@ -1,0 +1,2 @@
+jenkins/.vagrant
+.git


### PR DESCRIPTION
Excluding the `jenkins/.vagrant` folder speeds up rsync since we don't
waste time rysncing the disk image that vagrant uses to build our VMs.

Excluding the `.git` folder means we don't waste time syncing all the
diffs stored in `.git`.
