### PR TITLE
Prevent expensive download job triggering

### DIFF
--- a/jenkins/templates/jobs/update-jenkins.yml.j2
+++ b/jenkins/templates/jobs/update-jenkins.yml.j2
@@ -35,8 +35,6 @@
             url: git@github.com:livestax/dstl-lighthouse-builder.git
             branches:
                 - origin/master
-    triggers:
-        - github
     builders:
         - github-notifier
         - shell: |


### PR DESCRIPTION
No need to run this expensive job all the time. We know that we only
need to do it during a copper deploy.
