### PR TITLE
Django allowed host should be the hostname nginx use

### DIFF
--- a/ansible/roles/dstl.lighthouse/templates/wsgi.ini.j2
+++ b/ansible/roles/dstl.lighthouse/templates/wsgi.ini.j2
@@ -14,4 +14,4 @@ socket={{ uwsgi_socket_dir }}/lighthouse.socket
 touch-reload={{ lighthouse_location }}/.git/refs/heads/{{ lighthouse_version }}
 env=LIGHTHOUSE_DEBUG=False
 env=LIGHTHOUSE_SECRET_KEY={{ lighthouse_secret_key }}
-env=LIGHTHOUSE_ALLOWED_HOSTS={{ lighthouse_hostname }}
+env=LIGHTHOUSE_ALLOWED_HOSTS={{ lighthouse_nginx_proxy_host }}


### PR DESCRIPTION
Since we are using Nginx as our reverse proxy Django only sees the
hostname that Nginx specifically uses. We are in Nginx passing the
hostname using the `X-Forwarded-Host` header that you are meant to use
but it seems Django doesn't consider that.
