### PR TITLE
Speed up rpm downloads by not using ansible

### DIFF
--- a/ansible/roles/digi2al.dependencies/tasks/packages/package_rpms.yml
+++ b/ansible/roles/digi2al.dependencies/tasks/packages/package_rpms.yml
@@ -7,19 +7,10 @@
     - createrepo
 
 - name: Collect installed package names
-  shell: 'rpm -qa --queryformat "%{name}\n" | sort | grep --invert-match "gpg-pubkey"'
-  register: installed_packages
+  shell: 'rpm -qa --queryformat "%{name}\n" | sort | grep --invert-match "gpg-pubkey" > {{ remote_repo_location }}/pkg_list'
 
-- name: Package all installed RPMs
-  shell: "repotrack -p {{ remote_repo_location }}/yum {{ item }}"
-  with_items: "{{ installed_packages.stdout_lines }}"
-  when: "{{ super_deep_rpm_download }}"
-
-- name: Package installed RPMs
-  shell: "yumdownloader -q --destdir {{ remote_repo_location }}/yum {{ item }}"
-  args:
-    creates: "{{ remote_repo_location }}/yum/{{ item }}*.rpm"
-  with_items: "{{ installed_packages.stdout_lines }}"
+- name: Download all installed RPMs
+  shell: "yumdownloader --destdir {{ remote_repo_location }}/yum $(<{{ remote_repo_location }}/pkg_list)"
 
 - name: Create a yum repo
   shell: "createrepo {{ remote_repo_location }}/yum"


### PR DESCRIPTION
Using ansibles recommended way of iterating over the list of items lead
to x ssh connections + x yumdownloader mirror fetches introducing
massive lag in our rpm downloads.

By passing the entire list to yumdownloader it will only incur 1 ssh
connection and 1 yum mirror fetch plus yumdownloader.

I would have preferred to not chain so much shell together but again
ansible offers no way to manipulate lists of output or chain smaller
commands together. Because it's not a programming language and can never
be better than the composability of a proper scripting language.

/rant
