### PR TITLE
Only package the correct versions

### DIFF
--- a/ansible/roles/digi2al.dependencies/tasks/packages/package.yml
+++ b/ansible/roles/digi2al.dependencies/tasks/packages/package.yml
@@ -16,7 +16,7 @@
     - createrepo
 
 - name: Collect installed package names
-  shell: 'rpm -qa --queryformat "%{name}\n" | sort | grep --invert-match "gpg-pubkey" > {{ remote_repo_location }}/pkg_list'
+  shell: 'rpm -qa --queryformat "%{name}-%{version}\n" | sort | grep --invert-match "gpg-pubkey" > {{ remote_repo_location }}/pkg_list'
 
 - name: Download all installed RPMs
   shell: "yumdownloader --destdir {{ remote_repo_location }}/yum $(<{{ remote_repo_location }}/pkg_list)"


### PR DESCRIPTION
Using only `%{name}` in the rpm query will cause yumdownloader to
download the latest version of a package, not the version that is
installed.

The simple fix is to include `%{version}` in the rpm query.