### PR TITLE
Pin ansible to 2.1.1.0

### DIFF
--- a/ansible/bootstrap.sh
+++ b/ansible/bootstrap.sh
@@ -77,10 +77,17 @@ prepare_repo() {
   fi
 }
 
+install_rpm() {
+  /bin/rpm -q --quiet $1 || (/bin/echo "Install $1"; sudo /bin/yum -y install $1)
+}
+
 install_ansible() {
-  /bin/rpm -q --quiet ansible || ( /bin/echo "Install Ansible" ; sudo /bin/yum -y install ansible )
-  /bin/rpm -q --quiet python-pip || ( /bin/echo "Install Pip" ; sudo /bin/yum -y install python-pip )
-  sudo pip install --upgrade ansible $extra_pip_args
+  install_rpm libffi-devel
+  install_rpm gcc
+  install_rpm python-devel
+  install_rpm python-pip
+  install_rpm openssl-devel
+  sudo pip install ansible==2.1.1.0 $extra_pip_args
 }
 
 render_inventory() {


### PR DESCRIPTION
Ansible 2.2.0.0 has a bug that ignores conditionals on includes,
detailed in [ansible #17810](https://github.com/ansible/ansible/issues/17810).

In order to keep the repo working we are pinning our bootstrap to
install only 2.1.1.0 (last working release). In order to I've had to
install from pip, as 2.1.1.0 has been unpublished from EPEL, and with
that install all the dependencies that the RPM usually pulls in
automatically.