### PR TITLE
Properly enforce jenkins security

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -4,6 +4,7 @@
   vars_files:
     - vars/jenkins.yml
     - "{{ secrets_vars }}"
+    - ../secrets/all.secrets.yml
   roles:
     - digi2al.dependencies
     - digi2al.migration

--- a/ansible/roles/digi2al.jenkins/files/config.xml
+++ b/ansible/roles/digi2al.jenkins/files/config.xml
@@ -1,12 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson>
-  <disabledAdministrativeMonitors/>
+  <disabledAdministrativeMonitors>
+    <string>jenkins.security.s2m.MasterKillSwitchWarning</string>
+  </disabledAdministrativeMonitors>
   <version>1.0</version>
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
-  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
-  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
+    <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
+  </authorizationStrategy>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>true</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
   <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>

--- a/ansible/roles/openstack.jenkins-job-builder/handlers/main.yaml
+++ b/ansible/roles/openstack.jenkins-job-builder/handlers/main.yaml
@@ -14,7 +14,7 @@
 ---
 - name: Check jenkins
   delay: " {{ jenkins_job_builder_handler_check_delay }}"
-  shell: "curl --head --silent {{ jenkins_job_builder_config_jenkins_url }}"
+  shell: "curl --head --silent {{ jenkins_job_builder_config_jenkins_url }} --user {{ jenkins_job_builder_config_jenkins_user }}:{{ jenkins_job_builder_config_jenkins_password }}"
   register: result
   retries: "{{ jenkins_job_builder_handler_check_retries }}"
   until: result.stdout.find('200 OK') != -1

--- a/ansible/vars/jenkins.yml
+++ b/ansible/vars/jenkins.yml
@@ -3,7 +3,7 @@
 builder_repo: git@github.com:dstl/lighthouse-builder.git
 builder_version: origin/master
 
-jenkins_user: jenkins
+jenkins_user: 'jenkins'
 jenkins_plugins:
   - icon-shim
   - scm-api
@@ -23,6 +23,9 @@ jenkins_plugins:
 git_packages:
   - git2u
 
+jenkins_admin_username: '{{ jenkins_user }}'
+jenkins_admin_password: '{{ jenkins_pass }}'
+
 jenkins_job_builder_config_jenkins_url: http://localhost:8080
 jenkins_job_builder_file_jobs_src: ''
 jenkins_job_builder_user_name: '{{ jenkins_user }}'
@@ -30,6 +33,8 @@ jenkins_job_builder_user_group: '{{ jenkins_user }}'
 jenkins_job_builder_file_jobs_group: '{{ jenkins_user }}'
 jenkins_job_builder_file_jobs_owner: '{{ jenkins_user }}'
 jenkins_job_builder_install_method: 'pip'
+jenkins_job_builder_config_jenkins_user: '{{ jenkins_user }}'
+jenkins_job_builder_config_jenkins_password: '{{ jenkins_pass }}'
 
 jenkins_pypi_dist_location: '/opt/dist/pypi'
 


### PR DESCRIPTION
Now that the geerlingguy.jenkins role supports authentication (thanks to Jenkins 2 enforcing authentication) we need to support it.

This pull request ensures that we don't remove the security provided by jenkins authorization and makes the openstack.jenkins_job_builder role work nicely with it. (I intend to contribute this fix upstream soon).