### PR TITLE
Rebuild index job

### DIFF
--- a/ansible/roles/digi2al.jenkins/tasks/jobs.yml
+++ b/ansible/roles/digi2al.jenkins/tasks/jobs.yml
@@ -7,6 +7,7 @@
   with_items:
     - "update-jenkins.yml"
     - "lighthouse.yml"
+    - "management.yml"
 - name: "Force jobs to reload"
   command: /bin/true
   notify:

--- a/ansible/roles/digi2al.jenkins/templates/jobs/lighthouse.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/lighthouse.yml.j2
@@ -45,9 +45,6 @@
 {% endif %}
     triggers:
         - github
-        - reverse:
-            jobs: 'update-jenkins'
-            result: 'success'
     builders:
 {% if notify_github %}
         - github-notifier

--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -1,0 +1,43 @@
+- job:
+    name: 'rebuild-index'
+    description: 'Rebuilds the whoosh search index'
+    display-name: 'Rebuild search index'
+{% if distribute_dependencies %}
+    workspace: /opt/dist/workspaces/update-jenkins
+{% else %}
+    scm:
+        - git:
+            url: {{ builder_repo }}
+            branches:
+                - "origin/master"
+            submodule:
+                recursive: true
+{% endif %}
+    builders:
+        - shell: |
+            export SSH_USER="{{ lighthouse_ssh_user }}"
+            export SSH_PRIVATE_KEY_PATH="{{ lighthouse_ssh_key_path }}"
+            export LIGHTHOUSE_IP="{{ lighthouse_ip }}"
+            cd ansible
+
+            chmod 'u=rw,g=,o=' $SSH_PRIVATE_KEY_PATH
+
+            ssh -tt -i $SSH_PRIVATE_KEY_PATH \
+              $SSH_USER@$LIGHTHOUSE_IP \
+              -o IdentitiesOnly=yes << EOF
+
+              sudo su - lighthouse
+              source virtualenv/bin/activate
+              cd app
+              python manage.py rebuild_index --noinput
+
+              exit $?
+              exit $?
+            EOF
+    wrappers:
+        - ansicolor
+
+- project:
+    name: management
+    jobs:
+        - 'rebuild-index'


### PR DESCRIPTION
This pull request creates a job that sshs in to lighthouse and rebuilds the search index. Useful if you've just restored a database and need to ensure search still works.

![image](https://cloud.githubusercontent.com/assets/1446145/22001328/282ed866-dc3c-11e6-93e0-991ee0f97281.png)
