### PR TITLE
Ensure everything is up

### DIFF
--- a/ansible/roles/digi2al.python/handlers/main.yml
+++ b/ansible/roles/digi2al.python/handlers/main.yml
@@ -11,3 +11,4 @@
   service:
     name: nginx
     state: restarted
+    enabled: yes

--- a/ansible/roles/digi2al.python/handlers/main.yml
+++ b/ansible/roles/digi2al.python/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: emperor
     state: restarted
+    enabled: yes
 - name: reload systemd
   shell: systemctl daemon-reload
   sudo: true

--- a/ansible/roles/digi2al.python/tasks/nginx.yml
+++ b/ansible/roles/digi2al.python/tasks/nginx.yml
@@ -20,3 +20,4 @@
   service:
     name: nginx
     state: started
+    enabled: yes

--- a/ansible/roles/geerlingguy.jenkins/handlers/main.yml
+++ b/ansible/roles/geerlingguy.jenkins/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart jenkins
-  service: name=jenkins state=restarted
+  service: name=jenkins state=restarted enabled=yes
 
 - name: configure default users
   template:

--- a/ansible/roles/octarine.postgresql/handlers/main.yml
+++ b/ansible/roles/octarine.postgresql/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: restarted
+    enabled: yes

--- a/ansible/roles/octarine.postgresql/tasks/configure.yml
+++ b/ansible/roles/octarine.postgresql/tasks/configure.yml
@@ -152,4 +152,5 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: restarted
+    enabled: yes
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed

--- a/ansible/roles/octarine.postgresql/tasks/databases.yml
+++ b/ansible/roles/octarine.postgresql/tasks/databases.yml
@@ -4,6 +4,7 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: started
+    enabled: yes
 
 - name: PostgreSQL | Make sure the PostgreSQL databases are present
   postgresql_db:

--- a/ansible/roles/octarine.postgresql/tasks/users.yml
+++ b/ansible/roles/octarine.postgresql/tasks/users.yml
@@ -4,6 +4,7 @@
   service:
     name: "{{ postgresql_service_name }}"
     state: started
+    enabled: yes
 
 - name: PostgreSQL | Make sure the PostgreSQL users are present
   postgresql_user:


### PR DESCRIPTION
This pull request makes sure that emperor, nginx, jenkins and postgres all survive restarts by setting them as enabled.