### PR TITLE
Backup and restore

### DIFF
--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -37,6 +37,61 @@
     wrappers:
         - ansicolor
 
+- job:
+    name: 'backup-db'
+    description: 'Backup the lighthouse DB to jenkins'
+    display-name: 'Backup DB'
+    properties:
+        - build-discarder:
+            num-to-keep: 5
+            artifact-num-to-keep: 5
+{% if distribute_dependencies %}
+    workspace: /opt/dist/workspaces/update-jenkins
+{% else %}
+    scm:
+        - git:
+            url: {{ builder_repo }}
+            branches:
+                - "origin/master"
+            submodule:
+                recursive: true
+{% endif %}
+    builders:
+        - shell: |
+            export SSH_USER="{{ lighthouse_ssh_user }}"
+            export SSH_PRIVATE_KEY_PATH="{{ lighthouse_ssh_key_path }}"
+            export LIGHTHOUSE_IP="{{ lighthouse_ip }}"
+            cd ansible
+
+            chmod 'u=rw,g=,o=' $SSH_PRIVATE_KEY_PATH
+
+            ssh -tt -i $SSH_PRIVATE_KEY_PATH \
+              $SSH_USER@$LIGHTHOUSE_IP \
+              -o IdentitiesOnly=yes << EOF
+
+              sudo su - lighthouse
+              source virtualenv/bin/activate
+              cd app
+              python manage.py dumpdata > /tmp/db.json
+
+              exit $?
+
+              sudo chown {{ lighthouse_ssh_user }} /tmp/db.json
+              exit $?
+            EOF
+
+            rsync -avz \
+              -e "ssh -i $SSH_PRIVATE_KEY_PATH -o IdentitiesOnly=yes" \
+              $SSH_USER@$LIGHTHOUSE_IP:/tmp/db.json \
+              ./db.json
+    wrappers:
+        - ansicolor
+    publishers:
+      - archive:
+          artifacts: 'db.json'
+          allow-empty: false
+          only-if-success: true
+
 - project:
     name: management
     jobs:

--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -100,6 +100,71 @@
           allow-empty: false
           only-if-success: true
 
+- job:
+    name: 'restore-db'
+    description: 'Restore the lighthouse DB from a backup'
+    display-name: 'Restore DB'
+    parameters:
+        - file:
+            name: db.json
+            description: "Upload DB backup"
+{% if distribute_dependencies %}
+    workspace: /opt/dist/workspaces/update-jenkins
+{% else %}
+    scm:
+        - git:
+            url: {{ builder_repo }}
+            branches:
+                - "origin/master"
+            submodule:
+                recursive: true
+{% endif %}
+    builders:
+        - shell: |
+            export SSH_USER="{{ lighthouse_ssh_user }}"
+            export SSH_PRIVATE_KEY_PATH="{{ lighthouse_ssh_key_path }}"
+            export LIGHTHOUSE_IP="{{ lighthouse_ip }}"
+            SSH_CMD="ssh -i $SSH_PRIVATE_KEY_PATH -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+            cd ansible
+
+            chmod 'u=rw,g=,o=' $SSH_PRIVATE_KEY_PATH
+
+
+            $SSH_CMD -tt \
+              $SSH_USER@$LIGHTHOUSE_IP << EOF
+
+              # Create Backup directory, writeable by lighthouse
+              sudo mkdir -p /tmp/backups
+              sudo chmod o+w /tmp/backups
+              sudo rm /tmp/backups/db.json
+
+              exit $?
+            EOF
+
+            # Rsync backup to jenkins
+            rsync -avz \
+              -e "$SSH_CMD" \
+              ../db.json \
+              $SSH_USER@$LIGHTHOUSE_IP:/tmp/backups/db.json
+
+            $SSH_CMD -tt \
+              $SSH_USER@$LIGHTHOUSE_IP << EOF
+
+              # Become lighthouse and prepare environment
+              sudo su - lighthouse
+              source virtualenv/bin/activate
+              cd app
+
+              # Restore database
+              python manage.py loaddata /tmp/backups/db.json
+
+              exit $?
+              exit $?
+            EOF
+
+    wrappers:
+        - ansicolor
+
 - project:
     name: management
     jobs:

--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -24,6 +24,7 @@
 
             ssh -tt -i $SSH_PRIVATE_KEY_PATH \
               $SSH_USER@$LIGHTHOUSE_IP \
+              -o StrictHostKeyChecking=no \
               -o IdentitiesOnly=yes << EOF
 
               sudo su - lighthouse
@@ -61,13 +62,13 @@
             export SSH_USER="{{ lighthouse_ssh_user }}"
             export SSH_PRIVATE_KEY_PATH="{{ lighthouse_ssh_key_path }}"
             export LIGHTHOUSE_IP="{{ lighthouse_ip }}"
+            SSH_CMD="ssh -i $SSH_PRIVATE_KEY_PATH -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
             cd ansible
 
             chmod 'u=rw,g=,o=' $SSH_PRIVATE_KEY_PATH
 
-            ssh -tt -i $SSH_PRIVATE_KEY_PATH \
-              $SSH_USER@$LIGHTHOUSE_IP \
-              -o IdentitiesOnly=yes << EOF
+            $SSH_CMD -tt \
+              $SSH_USER@$LIGHTHOUSE_IP << EOF
 
               sudo su - lighthouse
               source virtualenv/bin/activate
@@ -81,7 +82,7 @@
             EOF
 
             rsync -avz \
-              -e "ssh -i $SSH_PRIVATE_KEY_PATH -o IdentitiesOnly=yes" \
+              -e "$SSH_CMD" \
               $SSH_USER@$LIGHTHOUSE_IP:/tmp/db.json \
               ./db.json
     wrappers:

--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -104,3 +104,4 @@
     name: management
     jobs:
         - 'rebuild-index'
+        - 'backup-db'

--- a/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
+++ b/ansible/roles/digi2al.jenkins/templates/jobs/management.yml.j2
@@ -70,21 +70,28 @@
             $SSH_CMD -tt \
               $SSH_USER@$LIGHTHOUSE_IP << EOF
 
+              # Create Backup directory, writeable by lighthouse
+              sudo mkdir -p /tmp/backups
+              sudo chmod o+w /tmp/backups
+              sudo rm /tmp/backups/db.json
+
+              # Become lighthouse and prepare environment
               sudo su - lighthouse
               source virtualenv/bin/activate
               cd app
-              python manage.py dumpdata > /tmp/db.json
+
+              # Backup database
+              python manage.py dumpdata > /tmp/backups/db.json
 
               exit $?
-
-              sudo chown {{ lighthouse_ssh_user }} /tmp/db.json
               exit $?
             EOF
 
+            # Rsync backup to jenkins
             rsync -avz \
               -e "$SSH_CMD" \
-              $SSH_USER@$LIGHTHOUSE_IP:/tmp/db.json \
-              ./db.json
+              $SSH_USER@$LIGHTHOUSE_IP:/tmp/backups/db.json \
+              ../db.json
     wrappers:
         - ansicolor
     publishers:


### PR DESCRIPTION
This pull request creates two jobs: Backup DB and Restore DB.

**Backup DB** uses `python manage.py dumpdata` to take a Django json dump of the entire database. It then rsyncs the file back to jenkins and archives it, so that it can be downloaded via the job detail page.

![artifacts](https://cloud.githubusercontent.com/assets/1446145/22127971/41b1bdf6-de96-11e6-8244-c7ff39700f29.png)

**Restore DB** uses `python manage.py loaddata` to restore a database from a Django json dump. You upload the backup via a file parameter when triggering the job. Jenkins then rsyncs the file to lighthouse and sshs in to restore the DB. Existing columns, records (where they match), and relationships are all preserved.

![restore](https://cloud.githubusercontent.com/assets/1446145/22128017/8c20850c-de96-11e6-948d-04cb558b97e5.png)
